### PR TITLE
Global

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -8,7 +8,7 @@ import { loadFragment } from '../fragment/fragment.js';
 export default async function decorate(block) {
   // load footer as fragment
   const footerMeta = getMetadata('footer');
-  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/footer';
+  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/global/footer';
   const fragment = await loadFragment(footerPath);
 
   // decorate footer DOM

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -176,7 +176,7 @@ async function buildBreadcrumbs() {
 export default async function decorate(block) {
   // load nav as fragment
   const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
+  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/global/nav';
   const fragment = await loadFragment(navPath);
 
   // decorate nav DOM


### PR DESCRIPTION
This pull request updates the paths used to load the navigation and footer fragments in the header and footer components, ensuring they reference the new global locations. This change helps standardize fragment loading and supports a more modular site structure.

**Fragment path updates:**

* Changed the default path for loading the footer fragment from `/footer` to `/global/footer` in `blocks/footer/footer.js`.
* Changed the default path for loading the navigation fragment from `/nav` to `/global/nav` in `blocks/header/header.js`.
